### PR TITLE
Update seeds

### DIFF
--- a/lib/plan_picker/enrollment.ex
+++ b/lib/plan_picker/enrollment.ex
@@ -2,6 +2,7 @@ defmodule PlanPicker.Enrollment do
   use PlanPicker.Schema
   import Ecto.Changeset
   import Ecto.Query, only: [from: 2]
+  alias PlanPicker.{Enrollment, Repo}
 
   schema "enrollments" do
     field :name, :string
@@ -23,7 +24,7 @@ defmodule PlanPicker.Enrollment do
         where: u.id == ^user.id,
         select: e
 
-    PlanPicker.Repo.all(query)
+    Repo.all(query)
   end
 
   @doc """
@@ -32,44 +33,44 @@ defmodule PlanPicker.Enrollment do
   def assign_user_to_enrollment(enrollment, user) do
     # fetch enrollment with associations
     enrollment =
-      PlanPicker.Enrollment
-      |> PlanPicker.Repo.get!(enrollment.id)
-      |> PlanPicker.Repo.preload(:users)
+      Enrollment
+      |> Repo.get!(enrollment.id)
+      |> Repo.preload(:users)
 
     enrollment
-    |> Ecto.Changeset.change()
-    |> Ecto.Changeset.put_assoc(:users, [user | enrollment.users])
-    |> PlanPicker.Repo.update!()
+    |> change()
+    |> put_assoc(:users, [user | enrollment.users])
+    |> Repo.update!()
   end
 
   def create_enrollment(enrollment_params) do
     %PlanPicker.Enrollment{state: :closed}
-    |> Ecto.Changeset.change()
-    |> PlanPicker.Enrollment.changeset(enrollment_params)
-    |> PlanPicker.Repo.insert!()
+    |> change()
+    |> Enrollment.changeset(enrollment_params)
+    |> Repo.insert!()
   end
 
   def get_enrollment!(enrollment_id, opts \\ %{preload: [:users, :subjects]}) do
-    PlanPicker.Enrollment
-    |> PlanPicker.Repo.get!(enrollment_id)
-    |> PlanPicker.Repo.preload(opts.preload)
+    Enrollment
+    |> Repo.get!(enrollment_id)
+    |> Repo.preload(opts.preload)
   end
 
   def get_all_enrollments do
-    PlanPicker.Repo.all(PlanPicker.Enrollment)
+    Repo.all(PlanPicker.Enrollment)
   end
 
   def update_enrollment(enrollment_id, enrollment_params) do
     PlanPicker.Enrollment
-    |> PlanPicker.Repo.get!(enrollment_id)
-    |> PlanPicker.Enrollment.changeset(enrollment_params)
-    |> PlanPicker.Repo.update!()
+    |> Repo.get!(enrollment_id)
+    |> Enrollment.changeset(enrollment_params)
+    |> Repo.update!()
   end
 
   def delete_enrollment(enrollment_id) do
-    PlanPicker.Enrollment
-    |> PlanPicker.Repo.get!(enrollment_id)
-    |> PlanPicker.Repo.delete!()
+    Enrollment
+    |> Repo.get!(enrollment_id)
+    |> Repo.delete!()
   end
 
   @doc false

--- a/lib/plan_picker/enrollment.ex
+++ b/lib/plan_picker/enrollment.ex
@@ -27,6 +27,10 @@ defmodule PlanPicker.Enrollment do
     Repo.all(query)
   end
 
+  def get_enrollment_by_name(name) do
+    Repo.get_by(Enrollment, name: name)
+  end
+
   @doc """
     Creates an association for Enrollment.users between enrollment and user.
   """

--- a/priv/repo/migrations/20210417133131_add_initial_schema.exs
+++ b/priv/repo/migrations/20210417133131_add_initial_schema.exs
@@ -157,12 +157,13 @@ defmodule PlanPicker.Repo.Migrations.AddInitialSchema do
       timestamps()
     end
 
-    create table(:enrollments_users) do
+    create table(:enrollments_users, primary_key: false) do
       add :user_id, references(:users, on_delete: :delete_all)
       add :enrollment_id, references(:enrollments, on_delete: :delete_all)
-
-      timestamps()
     end
+
+    create(index(:enrollments_users, [:user_id]))
+    create(index(:enrollments_users, [:enrollment_id]))
 
     create unique_index(:enrollments_users, [:user_id, :enrollment_id],
              name: "enrollments_users_unique_fk"

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -33,6 +33,14 @@ moderator =
 
 PlanPicker.Role.assign_role(moderator, :moderator)
 
+PlanPicker.Repo.insert!(%PlanPicker.Accounts.User{
+  email: "user@test.com",
+  hashed_password: Bcrypt.hash_pwd_salt("user"),
+  name: "user",
+  last_name: "user",
+  index_no: "000002"
+})
+
 "priv/repo/seeds/example_plan_data.csv"
 |> PlanPicker.DataLoader.import()
 |> PlanPicker.DataLoader.load_imported_data_to_db()

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,9 +9,10 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+alias PlanPicker.{Repo, Role, Accounts, DataLoader, Enrollment}
 
 admin =
-  PlanPicker.Repo.insert!(%PlanPicker.Accounts.User{
+  Repo.insert!(%PlanPicker.Accounts.User{
     email: "admin@test.com",
     hashed_password: Bcrypt.hash_pwd_salt("admin"),
     name: "admin",
@@ -19,11 +20,11 @@ admin =
     index_no: "000000"
   })
 
-PlanPicker.Role.assign_role(admin, :moderator)
-PlanPicker.Role.assign_role(admin, :admin)
+Role.assign_role(admin, :moderator)
+Role.assign_role(admin, :admin)
 
 moderator =
-  PlanPicker.Repo.insert!(%PlanPicker.Accounts.User{
+  Repo.insert!(%Accounts.User{
     email: "moderator@test.com",
     hashed_password: Bcrypt.hash_pwd_salt("moderator"),
     name: "moderator",
@@ -31,16 +32,20 @@ moderator =
     index_no: "000001"
   })
 
-PlanPicker.Role.assign_role(moderator, :moderator)
+Role.assign_role(moderator, :moderator)
 
-PlanPicker.Repo.insert!(%PlanPicker.Accounts.User{
-  email: "user@test.com",
-  hashed_password: Bcrypt.hash_pwd_salt("user"),
-  name: "user",
-  last_name: "user",
-  index_no: "000002"
-})
+user =
+  Repo.insert!(%Accounts.User{
+    email: "user@test.com",
+    hashed_password: Bcrypt.hash_pwd_salt("user"),
+    name: "user",
+    last_name: "user",
+    index_no: "000002"
+  })
 
 "priv/repo/seeds/example_plan_data.csv"
-|> PlanPicker.DataLoader.import()
-|> PlanPicker.DataLoader.load_imported_data_to_db()
+|> DataLoader.import()
+|> DataLoader.load_imported_data_to_db()
+
+enrollment = Enrollment.get_enrollment_by_name("3 semestr")
+Enrollment.assign_user_to_enrollment(enrollment, user)


### PR DESCRIPTION
- Removed `enrollments_users` primary key and timestamps fields to make it work with join_through
- Used data loader in `seeds.exs`
- Added user enrolled in one enrollment in `seeds.exs`
- Removed unnecessary prefixes in Repo and Ecto usages