### PR TITLE
Refactor roles and show enrollments on main screen

### DIFF
--- a/lib/plan_picker/role.ex
+++ b/lib/plan_picker/role.ex
@@ -3,6 +3,8 @@ defmodule PlanPicker.Role do
   import Ecto.Changeset
   import Ecto.Query, only: [from: 2]
 
+  alias PlanPicker.{Accounts, Repo, Role}
+
   schema "roles" do
     field :name, Ecto.Enum, values: [:moderator, :admin]
     belongs_to :user, PlanPicker.Accounts.User
@@ -15,11 +17,11 @@ defmodule PlanPicker.Role do
   """
   def has_role?(user, role_name) do
     query =
-      from u in PlanPicker.Accounts.User,
+      from u in Accounts.User,
         join: r in assoc(u, :role),
         where: r.name == ^role_name and u.id == ^user.id
 
-    PlanPicker.Repo.exists?(query)
+    Repo.exists?(query)
   end
 
   @doc """
@@ -29,11 +31,11 @@ defmodule PlanPicker.Role do
   """
   def assign_role(user, role_name) do
     if not has_role?(user, role_name) do
-      %PlanPicker.Role{name: role_name}
-      |> PlanPicker.Repo.preload(:user)
+      %Role{name: role_name}
+      |> Repo.preload(:user)
       |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:user, user)
-      |> PlanPicker.Repo.insert!()
+      |> Repo.insert!()
     end
   end
 
@@ -44,11 +46,11 @@ defmodule PlanPicker.Role do
   """
   def unassign_role(user, role_name) do
     query =
-      from u in PlanPicker.Accounts.User,
+      from u in Accounts.User,
         join: r in assoc(u, :role),
         where: r.name == ^role_name and u.id == ^user.id
 
-    PlanPicker.Repo.delete_all(query)
+    Repo.delete_all(query)
   end
 
   @doc false

--- a/lib/plan_picker/role.ex
+++ b/lib/plan_picker/role.ex
@@ -13,7 +13,10 @@ defmodule PlanPicker.Role do
   end
 
   def get_roles_for(user) do
-    Repo.preload(user, :role)
+    user
+    |> Ecto.assoc(:role)
+    |> Repo.all()
+    |> Enum.map(& &1.name)
   end
 
   @doc """

--- a/lib/plan_picker/role.ex
+++ b/lib/plan_picker/role.ex
@@ -12,6 +12,10 @@ defmodule PlanPicker.Role do
     timestamps()
   end
 
+  def get_roles_for(user) do
+    Repo.preload(user, :role)
+  end
+
   @doc """
   Checks whether the user has a role with name: role_name.
   """

--- a/lib/plan_picker_web.ex
+++ b/lib/plan_picker_web.ex
@@ -68,6 +68,7 @@ defmodule PlanPickerWeb do
 
       import PlanPickerWeb.ErrorHelpers
       import PlanPickerWeb.Gettext
+      import PlanPickerWeb.UserAuth, only: [current_user: 1, authenticated?: 1]
       alias PlanPickerWeb.Router.Helpers, as: Routes
     end
   end

--- a/lib/plan_picker_web/controllers/enrollment_controller.ex
+++ b/lib/plan_picker_web/controllers/enrollment_controller.ex
@@ -2,9 +2,10 @@ defmodule PlanPickerWeb.EnrollmentController do
   use PlanPickerWeb, :controller
 
   alias PlanPicker.Enrollment
+  alias PlanPickerWeb.UserAuth
 
   def index(conn, _params) do
-    enrollments = Enrollment.get_enrollments_for_user(conn.assigns[:current_user])
+    enrollments = conn |> UserAuth.current_user() |> Enrollment.get_enrollments_for_user()
 
     render(conn, "index.html", enrollments: enrollments)
   end

--- a/lib/plan_picker_web/controllers/page_controller.ex
+++ b/lib/plan_picker_web/controllers/page_controller.ex
@@ -1,10 +1,9 @@
 defmodule PlanPickerWeb.PageController do
   use PlanPickerWeb, :controller
-
-  alias PlanPicker.Role
+  import PlanPickerWeb.UserAuth, only: [current_user: 1]
 
   def index(conn, _params) do
-    case current_user = conn.assigns[:current_user] do
+    case current_user(conn) do
       nil ->
         render(conn, "anonymous_index.html")
 
@@ -12,7 +11,7 @@ defmodule PlanPickerWeb.PageController do
         render(conn, "index.html",
           is_moderator: Role.has_role?(user, :moderator),
           is_admin: Role.has_role?(user, :admin),
-          current_user: current_user
+          current_user: user
         )
     end
   end

--- a/lib/plan_picker_web/controllers/page_controller.ex
+++ b/lib/plan_picker_web/controllers/page_controller.ex
@@ -8,11 +8,7 @@ defmodule PlanPickerWeb.PageController do
         render(conn, "anonymous_index.html")
 
       user ->
-        render(conn, "index.html",
-          is_moderator: Role.has_role?(user, :moderator),
-          is_admin: Role.has_role?(user, :admin),
-          current_user: user
-        )
+        render(conn, "index.html", current_user: user)
     end
   end
 end

--- a/lib/plan_picker_web/controllers/page_controller.ex
+++ b/lib/plan_picker_web/controllers/page_controller.ex
@@ -1,14 +1,16 @@
 defmodule PlanPickerWeb.PageController do
   use PlanPickerWeb, :controller
 
+  alias PlanPicker.Role
+
   def index(conn, _params) do
     case conn.assigns[:current_user] do
       nil ->
         render(conn, "anonymous_index.html")
 
       user ->
-        moderator = PlanPicker.Role.has_role?(user, :moderator)
-        admin = PlanPicker.Role.has_role?(user, :admin)
+        moderator = Role.has_role?(user, :moderator)
+        admin = Role.has_role?(user, :admin)
         render(conn, "index.html", is_moderator: moderator, is_admin: admin)
     end
   end

--- a/lib/plan_picker_web/controllers/page_controller.ex
+++ b/lib/plan_picker_web/controllers/page_controller.ex
@@ -4,14 +4,16 @@ defmodule PlanPickerWeb.PageController do
   alias PlanPicker.Role
 
   def index(conn, _params) do
-    case conn.assigns[:current_user] do
+    case current_user = conn.assigns[:current_user] do
       nil ->
         render(conn, "anonymous_index.html")
 
       user ->
-        moderator = Role.has_role?(user, :moderator)
-        admin = Role.has_role?(user, :admin)
-        render(conn, "index.html", is_moderator: moderator, is_admin: admin)
+        render(conn, "index.html",
+          is_moderator: Role.has_role?(user, :moderator),
+          is_admin: Role.has_role?(user, :admin),
+          current_user: current_user
+        )
     end
   end
 end

--- a/lib/plan_picker_web/controllers/user_auth.ex
+++ b/lib/plan_picker_web/controllers/user_auth.ex
@@ -108,11 +108,19 @@ defmodule PlanPickerWeb.UserAuth do
     end
   end
 
+  def authenticated?(conn) do
+    !!conn.assigns[:current_user]
+  end
+
+  def current_user(conn) do
+    conn.assigns[:current_user]
+  end
+
   @doc """
   Used for routes that require the user to not be authenticated.
   """
   def redirect_if_user_is_authenticated(conn, _opts) do
-    if conn.assigns[:current_user] do
+    if authenticated?(conn) do
       conn
       |> redirect(to: signed_in_path(conn))
       |> halt()
@@ -128,7 +136,7 @@ defmodule PlanPickerWeb.UserAuth do
   they use the application at all, here would be a good place.
   """
   def require_authenticated_user(conn, _opts) do
-    if conn.assigns[:current_user] do
+    if authenticated?(conn) do
       conn
     else
       conn
@@ -145,7 +153,7 @@ defmodule PlanPickerWeb.UserAuth do
   Requires a user to be authenticated (connection must be piped through :require_authenticated_user first)
   """
   def require_role(conn, role) do
-    if PlanPicker.Role.has_role?(conn.assigns[:current_user], role) do
+    if Role.has_role?(current_user(conn), role) do
       conn
     else
       conn

--- a/lib/plan_picker_web/controllers/user_auth.ex
+++ b/lib/plan_picker_web/controllers/user_auth.ex
@@ -2,7 +2,7 @@ defmodule PlanPickerWeb.UserAuth do
   import Plug.Conn
   import Phoenix.Controller
 
-  alias PlanPicker.Accounts
+  alias PlanPicker.{Accounts, Role}
   alias PlanPickerWeb.Router.Helpers, as: Routes
 
   # Make the remember me cookie valid for 60 days.
@@ -160,6 +160,13 @@ defmodule PlanPickerWeb.UserAuth do
       |> put_flash(:error, "You do not have required permissions to view this page.")
       |> redirect(to: Routes.user_session_path(conn, :new))
       |> halt()
+    end
+  end
+
+  def put_roles_if_authenticated(conn, _opts) do
+    case current_user(conn) do
+      nil -> conn
+      user -> assign(conn, :roles, Role.get_roles_for(user))
     end
   end
 

--- a/lib/plan_picker_web/router.ex
+++ b/lib/plan_picker_web/router.ex
@@ -73,7 +73,6 @@ defmodule PlanPickerWeb.Router do
 
   scope "/", PlanPickerWeb do
     pipe_through [:browser, :require_authenticated_user]
-    get "/enrollments/", EnrollmentController, :index
     get "/enrollments/:id/show", EnrollmentController, :show
   end
 

--- a/lib/plan_picker_web/router.ex
+++ b/lib/plan_picker_web/router.ex
@@ -12,18 +12,23 @@ defmodule PlanPickerWeb.Router do
     plug :fetch_current_user
   end
 
-  pipeline :is_moderator do
+  pipeline :require_authenticated_user_having_data do
     plug :require_authenticated_user
+    plug :put_roles_if_authenticated
+  end
+
+  pipeline :require_moderator_role do
+    plug :require_authenticated_user_having_data
     plug :require_role, :moderator
   end
 
-  pipeline :is_admin do
-    plug :require_authenticated_user
+  pipeline :require_admin_role do
+    plug :require_authenticated_user_having_data
     plug :require_role, :admin
   end
 
   scope "/", PlanPickerWeb do
-    pipe_through :browser
+    pipe_through [:browser, :put_roles_if_authenticated]
 
     get "/", PageController, :index
   end
@@ -64,7 +69,7 @@ defmodule PlanPickerWeb.Router do
 
   ## User settings routes
   scope "/", PlanPickerWeb.Accounts do
-    pipe_through [:browser, :require_authenticated_user]
+    pipe_through [:browser, :require_authenticated_user_having_data]
 
     get "/users/settings", UserSettingsController, :edit
     put "/users/settings", UserSettingsController, :update
@@ -72,13 +77,13 @@ defmodule PlanPickerWeb.Router do
   end
 
   scope "/", PlanPickerWeb do
-    pipe_through [:browser, :require_authenticated_user]
+    pipe_through [:browser, :require_authenticated_user_having_data]
     get "/enrollments/:id/show", EnrollmentController, :show
   end
 
   # moderator or admin routes
   scope "/manage/", PlanPickerWeb do
-    pipe_through [:browser, :is_moderator]
+    pipe_through [:browser, :require_moderator_role]
 
     get "/enrollments/", EnrollmentManagementController, :index
     get "/enrollments/:id/show", EnrollmentManagementController, :show
@@ -88,7 +93,7 @@ defmodule PlanPickerWeb.Router do
 
   # admin only routes
   scope "/manage/", PlanPickerWeb do
-    pipe_through [:browser, :is_admin]
+    pipe_through [:browser, :require_admin_role]
 
     get "/enrollments/new", EnrollmentManagementController, :new
     post "/enrollments/", EnrollmentManagementController, :create

--- a/lib/plan_picker_web/templates/enrollment/index.html.eex
+++ b/lib/plan_picker_web/templates/enrollment/index.html.eex
@@ -1,7 +1,9 @@
-<h1> Your enrollments </h1>
+<div class="content">
+    <h1> Your enrollments </h1>
 
-<ol>
-    <%= for enrollment <- @enrollments do %>
-        <li> <%= link enrollment.name, to: Routes.enrollment_path(@conn, :show, enrollment.id) %> (<%= enrollment.state %>) </li>
-    <% end %>
-</ol>
+    <ol>
+        <%= for enrollment <- @enrollments do %>
+            <li> <%= link enrollment.name, to: Routes.enrollment_path(@conn, :show, enrollment.id) %> (<%= enrollment.state %>) </li>
+        <% end %>
+    </ol>
+</div>

--- a/lib/plan_picker_web/templates/layout/_navbar.html.eex
+++ b/lib/plan_picker_web/templates/layout/_navbar.html.eex
@@ -14,25 +14,10 @@
 
     <div class="navbar-end">
       <div class="navbar-item is-flex-direction-column">
-<%= if @current_user do %>
-        <div class="column">
-  <%= if @is_moderator do %>
-          <span class="tag is-primary">Moderator</span>
-  <% end %>
-  <%= if @is_admin do %>
-          <span class="tag is-primary">Admin</span>
-  <% end %>
-          <span class="is-size-6"><%= @current_user.email %></span>
-          </div>
-        <div class="buttons">
-          <%= link "Settings", to: Routes.user_settings_path(@conn, :edit), class: "button is-light" %>
-          <%= link "Log out", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "button is-light" %>
-        </div>
+<%= if authenticated?(@conn) do %>
+  <%= render "_navbar_logged_in.html", assigns %>
 <% else %>
-        <div class="buttons">
-          <%= link to: Routes.user_registration_path(@conn, :new), class: "button is-primary" do %><strong>Register</strong><% end %>
-          <%= link "Log in", to: Routes.user_session_path(@conn, :new), class: "button is-light" %>
-        </div>
+  <%= render "_navbar_logged_out.html" %>
 <% end %>
       </div>
     </div>

--- a/lib/plan_picker_web/templates/layout/_navbar.html.eex
+++ b/lib/plan_picker_web/templates/layout/_navbar.html.eex
@@ -17,7 +17,7 @@
 <%= if authenticated?(@conn) do %>
   <%= render "_navbar_logged_in.html", assigns %>
 <% else %>
-  <%= render "_navbar_logged_out.html" %>
+  <%= render "_navbar_logged_out.html", assigns %>
 <% end %>
       </div>
     </div>

--- a/lib/plan_picker_web/templates/layout/_navbar.html.eex
+++ b/lib/plan_picker_web/templates/layout/_navbar.html.eex
@@ -16,8 +16,12 @@
       <div class="navbar-item is-flex-direction-column">
 <%= if @current_user do %>
         <div class="column">
+  <%= if @is_moderator do %>
           <span class="tag is-primary">Moderator</span>
+  <% end %>
+  <%= if @is_admin do %>
           <span class="tag is-primary">Admin</span>
+  <% end %>
           <span class="is-size-6"><%= @current_user.email %></span>
           </div>
         <div class="buttons">

--- a/lib/plan_picker_web/templates/layout/_navbar_logged_in.html.eex
+++ b/lib/plan_picker_web/templates/layout/_navbar_logged_in.html.eex
@@ -1,0 +1,14 @@
+ <div class="column">
+  <div class="column">
+    <span class="is-size-6"><%= current_user(@conn).email %></span>
+<%= if :moderator in @roles do %>
+    <span class="tag is-primary">Moderator</span>
+<% end %>
+<%= if :admin in @roles do %>
+    <span class="tag is-primary">Admin</span>
+<% end %>
+  </div>
+  <div class="buttons">
+    <%= link "Settings", to: Routes.user_settings_path(@conn, :edit), class: "button is-light" %>
+    <%= link "Log out", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "button is-light" %>
+</div>

--- a/lib/plan_picker_web/templates/layout/_navbar_logged_out.html.eex
+++ b/lib/plan_picker_web/templates/layout/_navbar_logged_out.html.eex
@@ -1,0 +1,4 @@
+<div class="buttons">
+  <%= link to: Routes.user_registration_path(@conn, :new), class: "button is-primary" do %><strong>Register</strong><% end %>
+  <%= link "Log in", to: Routes.user_session_path(@conn, :new), class: "button is-light" %>
+</div>

--- a/lib/plan_picker_web/templates/page/index.html.eex
+++ b/lib/plan_picker_web/templates/page/index.html.eex
@@ -3,10 +3,10 @@
 <%= render_assigned_enrollments(@conn, @current_user) %>
 
 <ul>
-<%= if @is_moderator do %>
-<li><%= link "Manage enrollments", to: Routes.enrollment_management_path(@conn, :index) %></li>
+<%= if :moderator in @roles do %>
+  <li><%= link "Manage enrollments", to: Routes.enrollment_management_path(@conn, :index) %></li>
 <% end %>
-<%= if @is_admin do %>
-<li><%= link "Manage accounts", to: Routes.user_path(@conn, :index) %></li>
+<%= if :admin in @roles do %>
+  <li><%= link "Manage accounts", to: Routes.user_path(@conn, :index) %></li>
 <% end %>
 </ul>

--- a/lib/plan_picker_web/templates/page/index.html.eex
+++ b/lib/plan_picker_web/templates/page/index.html.eex
@@ -1,10 +1,12 @@
 <h1> Welcome to Plan Picker </h1>
+
+<%= render_assigned_enrollments(@conn, @current_user) %>
+
 <ul>
-<li><%= link "View your enrollments", to: Routes.enrollment_path(@conn, :index) %></li>
 <%= if @is_moderator do %>
-    <li><%= link "Manage enrollments", to: Routes.enrollment_management_path(@conn, :index) %></li>
+<li><%= link "Manage enrollments", to: Routes.enrollment_management_path(@conn, :index) %></li>
 <% end %>
 <%= if @is_admin do %>
-    <li><%= link "Manage accounts", to: Routes.user_path(@conn, :index) %></li>
+<li><%= link "Manage accounts", to: Routes.user_path(@conn, :index) %></li>
 <% end %>
 </ul>

--- a/lib/plan_picker_web/views/page_view.ex
+++ b/lib/plan_picker_web/views/page_view.ex
@@ -1,3 +1,11 @@
 defmodule PlanPickerWeb.PageView do
   use PlanPickerWeb, :view
+
+  alias PlanPicker.Enrollment
+
+  def render_assigned_enrollments(conn, current_user) do
+    enrollments = Enrollment.get_enrollments_for_user(current_user)
+
+    render(PlanPickerWeb.EnrollmentView, "index.html", conn: conn, enrollments: enrollments)
+  end
 end


### PR DESCRIPTION
# Changes

- Unify handling logged users in web by `UserAuth.current_user/1` and `UserAuth.authenticated?/1`
- Render {admin, moderator} pills based on assigned role
- Split navbar to logged and not logged partials
- Render assigned enrollments list on the main page
## Main Page
![image](https://user-images.githubusercontent.com/12465392/121780346-23289480-cba0-11eb-80c4-4f87c1516af1.png)
