### PR TITLE
Add LiveView class management

### DIFF
--- a/lib/plan_picker/accounts/user.ex
+++ b/lib/plan_picker/accounts/user.ex
@@ -15,7 +15,7 @@ defmodule PlanPicker.Accounts.User do
 
     has_many :role, PlanPicker.Role
     has_many :points_assignments, PlanPicker.PointsAssigment
-    many_to_many(:classes, PlanPicker.Class, join_through: "classes_users")
+    many_to_many(:classes, PlanPicker.Class, join_through: PlanPicker.ClassUser, on_replace: :delete)
 
     timestamps()
   end

--- a/lib/plan_picker/accounts/user.ex
+++ b/lib/plan_picker/accounts/user.ex
@@ -15,7 +15,11 @@ defmodule PlanPicker.Accounts.User do
 
     has_many :role, PlanPicker.Role
     has_many :points_assignments, PlanPicker.PointsAssigment
-    many_to_many(:classes, PlanPicker.Class, join_through: PlanPicker.ClassUser, on_replace: :delete)
+
+    many_to_many(:classes, PlanPicker.Class,
+      join_through: PlanPicker.ClassUser,
+      on_replace: :delete
+    )
 
     timestamps()
   end

--- a/lib/plan_picker/class.ex
+++ b/lib/plan_picker/class.ex
@@ -24,6 +24,12 @@ defmodule PlanPicker.Class do
     |> Repo.insert!()
   end
 
+  def get_class!(class_id, opts \\ [preload: [:teacher, :users, :terms]]) do
+    PlanPicker.Class
+    |> Repo.get!(class_id)
+    |> Repo.preload(opts[:preload])
+  end
+
   @doc false
   def changeset(class, attrs) do
     class

--- a/lib/plan_picker/class.ex
+++ b/lib/plan_picker/class.ex
@@ -9,7 +9,7 @@ defmodule PlanPicker.Class do
     belongs_to :teacher, PlanPicker.Teacher
     belongs_to :subject, PlanPicker.Subject
 
-    many_to_many :users, PlanPicker.Accounts.User, join_through: "classes_users"
+    many_to_many :users, PlanPicker.Accounts.User, join_through: PlanPicker.ClassUser, on_replace: :delete
     has_many :points_assignments, PlanPicker.PointsAssigment
     has_many :terms, PlanPicker.Term
 
@@ -28,6 +28,26 @@ defmodule PlanPicker.Class do
     PlanPicker.Class
     |> Repo.get!(class_id)
     |> Repo.preload(opts[:preload])
+  end
+
+  def assign_users_to_class!(class, users) do
+    class = Repo.preload(class, :users)
+
+    users = Enum.filter(users, &(!Enum.member?(class.users, &1)))
+
+    class
+    |> change()
+    |> put_assoc(:users, users ++ class.users)
+    |> Repo.update!()
+  end
+
+  def remove_user_from_class!(class, user) do
+    class = Repo.preload(class, :users)
+
+    class
+    |> change()
+    |> put_assoc(:users, List.delete(class.users, user))
+    |> Repo.update!()
   end
 
   @doc false

--- a/lib/plan_picker/class.ex
+++ b/lib/plan_picker/class.ex
@@ -9,7 +9,10 @@ defmodule PlanPicker.Class do
     belongs_to :teacher, PlanPicker.Teacher
     belongs_to :subject, PlanPicker.Subject
 
-    many_to_many :users, PlanPicker.Accounts.User, join_through: PlanPicker.ClassUser, on_replace: :delete
+    many_to_many :users, PlanPicker.Accounts.User,
+      join_through: PlanPicker.ClassUser,
+      on_replace: :delete
+
     has_many :points_assignments, PlanPicker.PointsAssigment
     has_many :terms, PlanPicker.Term
 

--- a/lib/plan_picker/class.ex
+++ b/lib/plan_picker/class.ex
@@ -36,11 +36,9 @@ defmodule PlanPicker.Class do
   def assign_users_to_class!(class, users) do
     class = Repo.preload(class, :users)
 
-    users = Enum.filter(users, &(!Enum.member?(class.users, &1)))
-
     class
     |> change()
-    |> put_assoc(:users, users ++ class.users)
+    |> put_assoc(:users, Enum.uniq(users ++ class.users))
     |> Repo.update!()
   end
 

--- a/lib/plan_picker/class_user.ex
+++ b/lib/plan_picker/class_user.ex
@@ -1,0 +1,10 @@
+defmodule PlanPicker.ClassUser do
+  use PlanPicker.Schema
+
+  schema "classes_users" do
+    belongs_to :user, PlanPicker.Accounts.User
+    belongs_to :class, PlanPicker.Class
+
+    timestamps()
+  end
+end

--- a/lib/plan_picker/subject.ex
+++ b/lib/plan_picker/subject.ex
@@ -20,6 +20,12 @@ defmodule PlanPicker.Subject do
     |> Repo.insert!()
   end
 
+  def get_subject!(subject_id, opts \\ [preload: [classes: [:teacher, :users, :terms]]]) do
+    PlanPicker.Subject
+    |> Repo.get!(subject_id)
+    |> Repo.preload(opts[:preload])
+  end
+
   @doc false
   def changeset(subject, attrs) do
     subject

--- a/lib/plan_picker_web/live/class_management_live.ex
+++ b/lib/plan_picker_web/live/class_management_live.ex
@@ -2,6 +2,18 @@ defmodule PlanPickerWeb.ClassManagementLive do
   use PlanPickerWeb, :live_view
   alias PlanPicker.{Accounts, Class, Enrollment, Subject}
 
+  def selected?(selected, el) when is_list(selected) do
+    Enum.member?(selected, el)
+  end
+
+  def selected?(nil, _) do
+    false
+  end
+
+  def selected?(selected, el) do
+    selected == el
+  end
+
   def mount(%{"id" => enrollment_id}, _session, socket) do
     enrollment = Enrollment.get_enrollment!(enrollment_id)
     subject = get_first_subject(enrollment)

--- a/lib/plan_picker_web/live/class_management_live.ex
+++ b/lib/plan_picker_web/live/class_management_live.ex
@@ -1,9 +1,10 @@
 defmodule PlanPickerWeb.ClassManagementLive do
   use PlanPickerWeb, :live_view
+  alias PlanPicker.{Accounts, Class, Enrollment, Subject}
 
   def mount(%{"id" => enrollment_id}, _session, socket) do
-    enrollment = PlanPicker.Enrollment.get_enrollment!(enrollment_id)
-    subject = get_subject(enrollment)
+    enrollment = Enrollment.get_enrollment!(enrollment_id)
+    subject = get_first_subject(enrollment)
 
     socket =
       socket
@@ -16,7 +17,7 @@ defmodule PlanPickerWeb.ClassManagementLive do
   end
 
   def handle_event("toggle_user", %{"id" => user_id}, socket) do
-    user = PlanPicker.Accounts.get_user!(user_id)
+    user = Accounts.get_user!(user_id)
 
     selected_users = socket.assigns[:selected_users]
 
@@ -33,7 +34,7 @@ defmodule PlanPickerWeb.ClassManagementLive do
         {:noreply, socket}
 
       _ ->
-        new_subject = PlanPicker.Subject.get_subject!(subject_id)
+        new_subject = Subject.get_subject!(subject_id)
         {:noreply, assign(socket, :selected_subject, new_subject)}
     end
   end
@@ -47,7 +48,7 @@ defmodule PlanPickerWeb.ClassManagementLive do
           {:noreply, socket}
 
         _ ->
-          new_class = PlanPicker.Class.get_class!(class_id)
+          new_class = Class.get_class!(class_id)
 
           selected_users =
             Enum.filter(socket.assigns[:selected_users], &(!Enum.member?(new_class.users, &1)))
@@ -60,7 +61,7 @@ defmodule PlanPickerWeb.ClassManagementLive do
           {:noreply, socket}
       end
     else
-      new_class = PlanPicker.Class.get_class!(class_id)
+      new_class = Class.get_class!(class_id)
 
       selected_users =
         Enum.filter(socket.assigns[:selected_users], &(!Enum.member?(new_class.users, &1)))
@@ -76,7 +77,7 @@ defmodule PlanPickerWeb.ClassManagementLive do
 
   def handle_event("add_users_to_class", _opts, socket) do
     new_class =
-      PlanPicker.Class.assign_users_to_class!(
+      Class.assign_users_to_class!(
         socket.assigns[:selected_class],
         socket.assigns[:selected_users]
       )
@@ -87,28 +88,28 @@ defmodule PlanPickerWeb.ClassManagementLive do
       socket
       |> assign(:selected_class, new_class)
       |> assign(:selected_users, [])
-      |> assign(:selected_subject, PlanPicker.Subject.get_subject!(subject.id))
+      |> assign(:selected_subject, Subject.get_subject!(subject.id))
 
     {:noreply, socket}
   end
 
   def handle_event("remove_user_from_class", %{"id" => user_id}, socket) do
     user = PlanPicker.Accounts.get_user!(user_id)
-    new_class = PlanPicker.Class.remove_user_from_class!(socket.assigns[:selected_class], user)
+    new_class = Class.remove_user_from_class!(socket.assigns[:selected_class], user)
 
     subject = socket.assigns[:selected_subject]
 
     socket =
       socket
       |> assign(:selected_class, new_class)
-      |> assign(:selected_subject, PlanPicker.Subject.get_subject!(subject.id))
+      |> assign(:selected_subject, Subject.get_subject!(subject.id))
 
     {:noreply, socket}
   end
 
-  defp get_subject(enrollment) do
+  defp get_first_subject(enrollment) do
     case enrollment.subjects do
-      [subject | _] -> PlanPicker.Subject.get_subject!(subject.id)
+      [subject | _] -> Subject.get_subject!(subject.id)
       nil -> nil
     end
   end

--- a/lib/plan_picker_web/live/class_management_live.ex
+++ b/lib/plan_picker_web/live/class_management_live.ex
@@ -2,6 +2,64 @@ defmodule PlanPickerWeb.ClassManagementLive do
   use PlanPickerWeb, :live_view
 
   def mount(%{"id" => enrollment_id}, _session, socket) do
-    {:ok, assign(socket, :enrollment_id, enrollment_id)}
+    enrollment = PlanPicker.Enrollment.get_enrollment!(enrollment_id)
+    subject = get_subject(enrollment)
+
+    socket =
+      socket
+      |> assign(:enrollment, enrollment)
+      |> assign(:selected_subject, subject)
+      |> assign(:selected_class, nil)
+      |> assign(:selected_users, [])
+
+    {:ok, socket}
+  end
+
+  def handle_event("toggle_user", %{"id" => user_id}, socket) do
+    user = PlanPicker.Accounts.get_user!(user_id)
+
+    selected_users = socket.assigns[:selected_users]
+
+    if Enum.member?(selected_users, user) do
+      {:noreply, assign(socket, :selected_users, List.delete(selected_users, user))}
+    else
+      {:noreply, assign(socket, :selected_users, [user | selected_users])}
+    end
+  end
+
+  def handle_event("select_subject", %{"id" => subject_id}, socket) do
+    case socket.assigns[:selected_subject].id do
+      ^subject_id ->
+        {:noreply, socket}
+
+      _ ->
+        new_subject = PlanPicker.Subject.get_subject!(subject_id)
+        {:noreply, assign(socket, :selected_subject, new_subject)}
+    end
+  end
+
+  def handle_event("select_class", %{"id" => class_id}, socket) do
+    selected_class = socket.assigns[:selected_class]
+
+    if selected_class do
+      case socket.assigns[:selected_class].id do
+        ^class_id ->
+          {:noreply, socket}
+
+        _ ->
+          new_class = PlanPicker.Class.get_class!(class_id)
+          {:noreply, assign(socket, :selected_class, new_class)}
+      end
+    else
+      new_class = PlanPicker.Class.get_class!(class_id)
+      {:noreply, assign(socket, :selected_class, new_class)}
+    end
+  end
+
+  defp get_subject(enrollment) do
+    case enrollment.subjects do
+      [subject | _] -> PlanPicker.Subject.get_subject!(subject.id)
+      nil -> nil
+    end
   end
 end

--- a/lib/plan_picker_web/live/class_management_live.ex
+++ b/lib/plan_picker_web/live/class_management_live.ex
@@ -21,7 +21,7 @@ defmodule PlanPickerWeb.ClassManagementLive do
 
     roles = Role.get_roles_for(user)
 
-    if Enum.member?(enrollment.users, user) || Enum.member?(roles, :admin) do
+    if Enum.member?(enrollment.users, user) || :admin in roles do
       subject = get_first_subject(enrollment)
 
       socket =

--- a/lib/plan_picker_web/live/class_management_live.ex
+++ b/lib/plan_picker_web/live/class_management_live.ex
@@ -21,25 +21,24 @@ defmodule PlanPickerWeb.ClassManagementLive do
 
     roles = Role.get_roles_for(user)
 
-    case {Enum.member?(enrollment.users, user), Enum.member?(roles, :admin)} do
-      {false, false} ->
-        socket = socket
+    if Enum.member?(enrollment.users, user) || Enum.member?(roles, :admin) do
+      subject = get_first_subject(enrollment)
+
+      socket =
+        socket
+        |> assign(:enrollment, enrollment)
+        |> assign(:selected_subject, subject)
+        |> assign(:selected_class, nil)
+        |> assign(:selected_users, [])
+
+      {:ok, socket}
+    else
+      socket =
+        socket
         |> put_flash(:error, "You do not have required permissions to view this enrollment.")
         |> redirect(to: Routes.enrollment_management_path(socket, :index))
 
-        {:ok, socket}
-
-      {_, _} ->
-        subject = get_first_subject(enrollment)
-
-        socket =
-          socket
-          |> assign(:enrollment, enrollment)
-          |> assign(:selected_subject, subject)
-          |> assign(:selected_class, nil)
-          |> assign(:selected_users, [])
-
-        {:ok, socket}
+      {:ok, socket}
     end
   end
 

--- a/lib/plan_picker_web/live/class_management_live.html.leex
+++ b/lib/plan_picker_web/live/class_management_live.html.leex
@@ -1,1 +1,52 @@
-TODO: Classes live view
+<h1 class="title"> Classes in <%= @enrollment.name %> </h1>
+<div class="columns">
+    <div class="column is-one-quarter">
+        <%= if length(@enrollment.users) == 0 do %>
+            There are no users assigned to this enrollment.
+        <% end %>
+        <%= for user <- @enrollment.users do %>
+            <button class="button<%= if Enum.member?(@selected_users, user) do " is-primary" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
+                <%= user.name %> <%= user.last_name %>
+            </button>
+        <% end %>
+    </div>
+    <div class="column">
+        <div class="tabs is-toggle is-centered is-fullwidth">
+            <ul>
+                <%= for subject <- @enrollment.subjects do %>
+                    <%= if @selected_subject.id == subject.id do %>
+                        <li class="is-active">
+                            <a> <%= subject.name %> </a>
+                        </li>
+                    <% else %>
+                        <li phx-click="select_subject" phx-value-id="<%= subject.id %>">
+                            <a> <%= subject.name %> </a>
+                        </li>
+                    <% end %>
+                <% end %>
+            </ul>
+        </div>
+        <%= if length(@selected_subject.classes) == 0 do %>
+            <div class="box">
+                There are no classes in this subject.
+            </div>
+        <% end %>
+        <%= for class <- @selected_subject.classes do %>
+            <div class="box" phx-click="select_class" phx-value-id="<%= class.id %>">
+                <h2 class="subtitle"> <%= class.teacher.name %> <%= class.teacher.surname %> <h2>
+                <%= for term <- class.terms do %>
+                    <div class="content"> <%= term.interval %> </div>
+                <% end %>
+                <%= if @selected_class && class.id == @selected_class.id do %>
+                    <%= if length(@selected_users) == 0 do %>
+                        <button class="button" disabled>Select at least one user</button>
+                    <% else %>
+                        <button class="button is-primary">Add <%= length(@selected_users) %> user(s) to group</button>
+                    <% end %>
+                <% else %>
+                    <div class="content"> <%= length(class.users) %> assigned to this group. </div>
+                <% end %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/lib/plan_picker_web/live/class_management_live.html.leex
+++ b/lib/plan_picker_web/live/class_management_live.html.leex
@@ -49,8 +49,8 @@
             <div class="box" phx-click="select_class" phx-value-id="<%= class.id %>">
                 <h2 class="subtitle"> <%= class.teacher.name %> <%= class.teacher.surname %> <h2>
 
-                <%= for term <- class.terms do %>
-                    <div class="content"> <%= term.interval %> </div>
+                <%= for {term,i} <- Enum.with_index(class.terms, 1) do %>
+                    <div class="is-size-6">Term <%= i %>: <%= Timestamp.Range.to_human_readable_iodata(term.interval) %> </div>
                 <% end %>
 
                 <%= if selected?(@selected_class, class) do %>
@@ -71,7 +71,7 @@
                         </tbody>
                     </table>
                 <% else %>
-                    <div class="content"> <%= length(class.users) %> assigned to this group. </div>
+                    <span class="is-size-5"> <%= length(class.users) %> assigned to this group. </span>
                 <% end %>
             </div>
         <% end %>

--- a/lib/plan_picker_web/live/class_management_live.html.leex
+++ b/lib/plan_picker_web/live/class_management_live.html.leex
@@ -4,12 +4,24 @@
         <%= if length(@enrollment.users) == 0 do %>
             There are no users assigned to this enrollment.
         <% end %>
-        <%= for user <- @enrollment.users do %>
-            <button class="button<%= if Enum.member?(@selected_users, user) do " is-primary" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
-                <%= user.name %> <%= user.last_name %>
-            </button>
-        <% end %>
+
+        <table class="table is-fullwidth is-hoverable is-striped">
+            <%= for user <- @enrollment.users do %>
+                <tr>
+                    <%= if @selected_class && Enum.member?(@selected_class.users, user) do %>
+                        <td>
+                            <del> <%= user.name %> <%= user.last_name %> </del>
+                        </td>
+                    <% else %>
+                        <td class="<%= if Enum.member?(@selected_users, user) do "is-selected" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
+                            <%= user.name %> <%= user.last_name %>
+                        </td>
+                    <% end %>
+                <tr>
+            <% end %>
+        </table>
     </div>
+
     <div class="column">
         <div class="tabs is-toggle is-centered is-fullwidth">
             <ul>
@@ -26,23 +38,38 @@
                 <% end %>
             </ul>
         </div>
+
         <%= if length(@selected_subject.classes) == 0 do %>
             <div class="box">
                 There are no classes in this subject.
             </div>
         <% end %>
+
         <%= for class <- @selected_subject.classes do %>
             <div class="box" phx-click="select_class" phx-value-id="<%= class.id %>">
                 <h2 class="subtitle"> <%= class.teacher.name %> <%= class.teacher.surname %> <h2>
+
                 <%= for term <- class.terms do %>
                     <div class="content"> <%= term.interval %> </div>
                 <% end %>
+
                 <%= if @selected_class && class.id == @selected_class.id do %>
                     <%= if length(@selected_users) == 0 do %>
                         <button class="button" disabled>Select at least one user</button>
                     <% else %>
-                        <button class="button is-primary">Add <%= length(@selected_users) %> user(s) to group</button>
+                        <button class="button is-primary" phx-click="add_users_to_class">Add <%= length(@selected_users) %> user(s) to group</button>
                     <% end %>
+
+                    <table class="table is-fullwidth is-hoverable is-striped">
+                        <tbody>
+                            <%= for user <- class.users do %>
+                                <tr class="content">
+                                    <td> <%= user.name %> <%= user.last_name %> </td>
+                                    <td> <button class="button is-danger" phx-click="remove_user_from_class" phx-value-id="<%= user.id %>"> Remove from group </button> </td>
+                                </tr>
+                            <% end %>
+                        </tbody>
+                    </table>
                 <% else %>
                     <div class="content"> <%= length(class.users) %> assigned to this group. </div>
                 <% end %>

--- a/lib/plan_picker_web/live/class_management_live.html.leex
+++ b/lib/plan_picker_web/live/class_management_live.html.leex
@@ -8,12 +8,12 @@
         <table class="table is-fullwidth is-hoverable is-striped">
             <%= for user <- @enrollment.users do %>
                 <tr>
-                    <%= if @selected_class && Enum.member?(@selected_class.users, user) do %>
+                    <%= if @selected_class && selected?(@selected_class.users, user) do %>
                         <td>
                             <del> <%= user.name %> <%= user.last_name %> </del>
                         </td>
                     <% else %>
-                        <td class="<%= if Enum.member?(@selected_users, user) do "is-selected" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
+                        <td class="<%= if selected?(@selected_users, user) do "is-selected" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
                             <%= user.name %> <%= user.last_name %>
                         </td>
                     <% end %>
@@ -26,7 +26,7 @@
         <div class="tabs is-toggle is-centered is-fullwidth">
             <ul>
                 <%= for subject <- @enrollment.subjects do %>
-                    <%= if @selected_subject.id == subject.id do %>
+                    <%= if selected?(@selected_subject.id, subject.id) do %>
                         <li class="is-active">
                             <a> <%= subject.name %> </a>
                         </li>
@@ -53,7 +53,7 @@
                     <div class="content"> <%= term.interval %> </div>
                 <% end %>
 
-                <%= if @selected_class && class.id == @selected_class.id do %>
+                <%= if selected?(@selected_class, class) do %>
                     <%= if length(@selected_users) == 0 do %>
                         <button class="button" disabled>Select at least one user</button>
                     <% else %>


### PR DESCRIPTION
This is the most basic functionality of group management. Will probably need to be polished up but better to have it here for review.

The main screen looks like this:
![image](https://user-images.githubusercontent.com/39308576/121788943-fab98e00-cbd1-11eb-8870-d657a067f45e.png)

You can switch between different subject using the tags
![image](https://user-images.githubusercontent.com/39308576/121788960-12911200-cbd2-11eb-9ebe-3a9fe149e290.png)

Clicking on a class will select it, prompting you to select a user (as well as displaying a list of assigned users, but here there are none at the moment)
![image](https://user-images.githubusercontent.com/39308576/121788976-3d7b6600-cbd2-11eb-943c-a7e9ddca22b2.png)

Clicking on a user will select it, enabling us to add them to the class
![image](https://user-images.githubusercontent.com/39308576/121788989-571cad80-cbd2-11eb-8a40-20f85b814ba7.png)

After adding the user, we cannot select it in the scope of that group
![image](https://user-images.githubusercontent.com/39308576/121789013-8a5f3c80-cbd2-11eb-92f1-514d950d62ef.png)

We can, however, remove them from group to come back to the beginning state
![image](https://user-images.githubusercontent.com/39308576/121789021-a662de00-cbd2-11eb-9bce-798f74c0ad6e.png)

The system should hold up when switching groups/users a lot, but i havent really checked all the nooks of it yet