### PR TITLE
Add enrollment management

### DIFF
--- a/lib/plan_picker/accounts.ex
+++ b/lib/plan_picker/accounts.ex
@@ -59,6 +59,10 @@ defmodule PlanPicker.Accounts do
   """
   def get_user!(id), do: Repo.get!(User, id)
 
+  def get_all_users do
+    Repo.all(User)
+  end
+
   ## User registration
 
   @doc """

--- a/lib/plan_picker/enrollment.ex
+++ b/lib/plan_picker/enrollment.ex
@@ -84,14 +84,13 @@ defmodule PlanPicker.Enrollment do
     Repo.all(PlanPicker.Enrollment)
   end
 
-  def update_enrollment(enrollment_id, enrollment_params) do
-    PlanPicker.Enrollment
-    |> Repo.get!(enrollment_id)
+  def update_enrollment!(enrollment, enrollment_params) do
+    enrollment
     |> Enrollment.changeset(enrollment_params)
     |> Repo.update!()
   end
 
-  def delete_enrollment(enrollment_id) do
+  def delete_enrollment!(enrollment_id) do
     Enrollment
     |> Repo.get!(enrollment_id)
     |> Repo.delete!()

--- a/lib/plan_picker/enrollment.ex
+++ b/lib/plan_picker/enrollment.ex
@@ -50,11 +50,9 @@ defmodule PlanPicker.Enrollment do
   def assign_users_to_enrollment!(enrollment, users) do
     enrollment = Repo.preload(enrollment, :users)
 
-    users = Enum.filter(users, &(!Enum.member?(enrollment.users, &1)))
-
     enrollment
     |> change()
-    |> put_assoc(:users, users ++ enrollment.users)
+    |> put_assoc(:users, Enum.uniq(users ++ enrollment.users))
     |> Repo.update!()
   end
 
@@ -63,7 +61,7 @@ defmodule PlanPicker.Enrollment do
 
     enrollment
     |> change()
-    |> put_assoc(:users, Enum.filter(enrollment.users, &(!Enum.member?(users, &1))))
+    |> put_assoc(:users, Enum.filter(enrollment.users, &(&1 not in users)))
     |> Repo.update!()
   end
 

--- a/lib/plan_picker_web.ex
+++ b/lib/plan_picker_web.ex
@@ -71,6 +71,7 @@ defmodule PlanPickerWeb do
       import Phoenix.LiveView.Helpers
 
       import PlanPickerWeb.ErrorHelpers
+      import PlanPickerWeb.RoleHelpers
       import PlanPickerWeb.Gettext
       import PlanPickerWeb.UserAuth, only: [current_user: 1, authenticated?: 1]
       alias PlanPickerWeb.Router.Helpers, as: Routes

--- a/lib/plan_picker_web/controllers/enrollment_management_controller.ex
+++ b/lib/plan_picker_web/controllers/enrollment_management_controller.ex
@@ -5,7 +5,7 @@ defmodule PlanPickerWeb.EnrollmentManagementController do
   alias PlanPickerWeb.UserAuth
 
   def index(conn, _params) do
-    if Enum.member?(conn.assigns[:roles], :admin) do
+    if :admin in conn.assigns[:roles] do
       render(conn, "index.html", enrollments: Enrollment.get_all_enrollments())
     else
       enrollments = conn |> UserAuth.current_user() |> Enrollment.get_enrollments_for_user()

--- a/lib/plan_picker_web/controllers/enrollment_management_controller.ex
+++ b/lib/plan_picker_web/controllers/enrollment_management_controller.ex
@@ -35,29 +35,8 @@ defmodule PlanPickerWeb.EnrollmentManagementController do
     |> redirect(to: Routes.enrollment_management_path(conn, :show, enrollment.id))
   end
 
-  def edit(conn, %{"id" => enrollment_id}) do
-    changeset =
-      Enrollment.get_enrollment!(enrollment_id)
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.cast(%{}, [:id])
-
-    render(conn, "edit.html",
-      changeset: changeset,
-      state_options: Enrollment.state_options(),
-      enrollment_id: enrollment_id
-    )
-  end
-
-  def update(conn, %{"enrollment" => enrollment_params, "id" => enrollment_id}) do
-    Enrollment.update_enrollment(enrollment_id, enrollment_params)
-
-    conn
-    |> put_flash(:info, "Enrollment updated")
-    |> redirect(to: Routes.enrollment_management_path(conn, :show, enrollment_id))
-  end
-
   def delete(conn, %{"id" => enrollment_id}) do
-    Enrollment.delete_enrollment(enrollment_id)
+    Enrollment.delete_enrollment!(enrollment_id)
 
     conn
     |> put_flash(:info, "Enrollment deleted.")

--- a/lib/plan_picker_web/controllers/enrollment_management_controller.ex
+++ b/lib/plan_picker_web/controllers/enrollment_management_controller.ex
@@ -2,11 +2,17 @@ defmodule PlanPickerWeb.EnrollmentManagementController do
   use PlanPickerWeb, :controller
 
   alias PlanPicker.Enrollment
+  alias PlanPickerWeb.UserAuth
 
   def index(conn, _params) do
-    enrollments = Enrollment.get_all_enrollments()
-
-    render(conn, "index.html", enrollments: enrollments)
+    if Enum.member?(conn.assigns[:roles], :admin) do
+      render(conn, "index.html", enrollments: Enrollment.get_all_enrollments())
+    else
+      enrollments = conn |> UserAuth.current_user() |> Enrollment.get_enrollments_for_user()
+      render(conn, "index.html",
+        enrollments: enrollments
+      )
+    end
   end
 
   def show(conn, %{"id" => enrollment_id}) do

--- a/lib/plan_picker_web/live/enrollment_management_live.ex
+++ b/lib/plan_picker_web/live/enrollment_management_live.ex
@@ -1,0 +1,43 @@
+defmodule PlanPickerWeb.EnrollmentManagementLive do
+  use PlanPickerWeb, :live_view
+
+  def render(assigns) do
+    Phoenix.View.render(PlanPickerWeb.EnrollmentManagementView, "edit.html", assigns)
+  end
+
+  def mount(%{"id" => enrollment_id}, _opts, socket) do
+    enrollment = PlanPicker.Enrollment.get_enrollment!(enrollment_id)
+    changeset = Ecto.Changeset.change(enrollment)
+
+    socket =
+      socket
+      |> assign(:enrollment, enrollment)
+      |> assign(:changeset, changeset)
+      |> assign(:state_options, PlanPicker.Enrollment.state_options())
+
+    {:ok, socket}
+  end
+
+  def handle_event("validate", %{"enrollment" => _enrollment_params}, socket) do
+    # TODO: validation
+    {:noreply, socket}
+  end
+
+  def handle_event("submit", %{"enrollment" => enrollment_params}, socket) do
+    new_enrollment =
+      PlanPicker.Enrollment.update_enrollment(
+        socket.assigns[:enrollment].id,
+        enrollment_params
+      )
+
+    changeset = Ecto.Changeset.change(new_enrollment)
+
+    socket =
+      socket
+      |> assign(:enrollment, new_enrollment)
+      |> assign(:changeset, changeset)
+      |> put_flash(:info, "Enrollment updated.")
+
+    {:noreply, socket}
+  end
+end

--- a/lib/plan_picker_web/live/enrollment_management_live.ex
+++ b/lib/plan_picker_web/live/enrollment_management_live.ex
@@ -46,8 +46,8 @@ defmodule PlanPickerWeb.EnrollmentManagementLive do
 
   def handle_event("submit", %{"enrollment" => enrollment_params}, socket) do
     new_enrollment =
-      Enrollment.update_enrollment(
-        socket.assigns[:enrollment].id,
+      Enrollment.update_enrollment!(
+        socket.assigns[:enrollment],
         enrollment_params
       )
 

--- a/lib/plan_picker_web/live/enrollment_management_live.ex
+++ b/lib/plan_picker_web/live/enrollment_management_live.ex
@@ -14,10 +14,10 @@ defmodule PlanPickerWeb.EnrollmentManagementLive do
 
     roles = Role.get_roles_for(user)
 
-    if Enum.member?(enrollment.users, user) || :admin in roles do
-      changeset = change(enrollment)
+    socket =
+      if user in enrollment.users || :admin in roles do
+        changeset = change(enrollment)
 
-      socket =
         socket
         |> assign(:enrollment, enrollment)
         |> assign(:changeset, changeset)
@@ -27,16 +27,13 @@ defmodule PlanPickerWeb.EnrollmentManagementLive do
           :available_users,
           Enum.filter(PlanPicker.Accounts.get_all_users(), &(!Enum.member?(enrollment.users, &1)))
         )
-
-      {:ok, socket}
-    else
-      socket =
+      else
         socket
         |> put_flash(:error, "You do not have the required permissions to edit this enrollment.")
         |> redirect(to: Routes.enrollment_management_path(socket, :index))
+      end
 
-      {:ok, socket}
-    end
+    {:ok, socket}
   end
 
   def handle_event("validate", %{"enrollment" => _enrollment_params}, socket) do

--- a/lib/plan_picker_web/live/enrollment_management_live.ex
+++ b/lib/plan_picker_web/live/enrollment_management_live.ex
@@ -14,7 +14,7 @@ defmodule PlanPickerWeb.EnrollmentManagementLive do
 
     roles = Role.get_roles_for(user)
 
-    if Enum.member?(enrollment.users, user) || Enum.member?(roles, :admin) do
+    if Enum.member?(enrollment.users, user) || :admin in roles do
       changeset = change(enrollment)
 
       socket =

--- a/lib/plan_picker_web/router.ex
+++ b/lib/plan_picker_web/router.ex
@@ -88,7 +88,7 @@ defmodule PlanPickerWeb.Router do
 
     get "/enrollments/", EnrollmentManagementController, :index
     get "/enrollments/:id/show", EnrollmentManagementController, :show
-    get "/enrollments/:id/edit", EnrollmentManagementController, :edit
+    live "/enrollments/:id/edit", EnrollmentManagementLive, :edit
     put "/enrollments/", EnrollmentManagementController, :update
 
     live "/enrollments/:id/classes", ClassManagementLive

--- a/lib/plan_picker_web/router.ex
+++ b/lib/plan_picker_web/router.ex
@@ -89,7 +89,6 @@ defmodule PlanPickerWeb.Router do
     get "/enrollments/", EnrollmentManagementController, :index
     get "/enrollments/:id/show", EnrollmentManagementController, :show
     live "/enrollments/:id/edit", EnrollmentManagementLive, :edit
-    put "/enrollments/", EnrollmentManagementController, :update
 
     live "/enrollments/:id/classes", ClassManagementLive
   end

--- a/lib/plan_picker_web/templates/enrollment_management/_user_list.html.leex
+++ b/lib/plan_picker_web/templates/enrollment_management/_user_list.html.leex
@@ -7,7 +7,7 @@
     <tbody>
         <%= for user <- @users do %>
             <tr>
-                <td class="<%= if Enum.member?(@selected_users, user) do "is-selected" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
+                <td class="<%= if selected?(@selected_users, user) do "is-selected" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
                     <%= user.name %> <%= user.last_name %>, <%= user.index_no %>
                 </td>
             </tr>

--- a/lib/plan_picker_web/templates/enrollment_management/_user_list.html.leex
+++ b/lib/plan_picker_web/templates/enrollment_management/_user_list.html.leex
@@ -1,0 +1,16 @@
+<table class="table is-striped is-hoverable is-fullwidth">
+    <thead>
+        <tr>
+            <th> <%= @prompt %> </th>
+        </tr>
+    </thead>
+    <tbody>
+        <%= for user <- @users do %>
+            <tr>
+                <td class="<%= if Enum.member?(@selected_users, user) do "is-selected" end %>" phx-click="toggle_user" phx-value-id="<%= user.id %>">
+                    <%= user.name %> <%= user.last_name %>, <%= user.index_no %>
+                </td>
+            </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/lib/plan_picker_web/templates/enrollment_management/edit.html.leex
+++ b/lib/plan_picker_web/templates/enrollment_management/edit.html.leex
@@ -1,27 +1,45 @@
-<div class="column is-one-quarter">
-    <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :submit] %>
-        <%= if @changeset.action do %>
-            <div class="alert alert-danger">
-                <p>Oops, something went wrong! Please check the errors below.</p>
-            </div>
-        <% end %>
+<h1 class="title"> Edit <%= @enrollment.name %> </h1>
+<div class="columns">
+    <div class="column is-one-fifth">
+        <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :submit] %>
+            <%= if @changeset.action do %>
+                <div class="alert alert-danger">
+                    <p>Oops, something went wrong! Please check the errors below.</p>
+                </div>
+            <% end %>
 
-        <div class="field">
-            <%= label f, :name, "Enrollment name", class: "label" %>
-            <div class="control">
-                <%= text_input f, :name, required: true, class: "input" %>
-                <%= error_tag f, :name %>
+            <div class="field">
+                <%= label f, :name, "Enrollment name", class: "label" %>
+                <div class="control">
+                    <%= text_input f, :name, required: true, class: "input" %>
+                    <%= error_tag f, :name %>
+                </div>
             </div>
+
+            <div class="field">
+                <%= label f, :state, "State", class: "label" %>
+                <div class="control">
+                    <div class="select"><%= select f, :state, @state_options %></div>
+                    <%= error_tag f, :state %>
+                </div>
+            </div>
+
+            <%= submit "Save changes", class: "button is-link" %>
+        </form>
+    </div>
+
+    <div class="columns column is-two-fifths">
+        <div class="column">
+            <button class="button is-primary is-fullwidth" phx-click="assign_users">
+                Assign users &rarr;
+            </button>
+            <%= render "_user_list.html", socket: @socket, users: @available_users, selected_users: @selected_users, prompt: "Available users" %>
         </div>
-
-        <div class="field">
-            <%= label f, :state, "State", class: "label" %>
-            <div class="control">
-                <div class="select"><%= select f, :state, @state_options %></div>
-                <%= error_tag f, :state %>
-            </div>
+        <div class="column">
+            <button class="button is-danger is-fullwidth" phx-click="unassign_users">
+                &larr; Unassign users
+            </button>
+            <%= render "_user_list.html", socket: @socket, users: @enrollment.users, selected_users: @selected_users, prompt: "Assigned users" %>
         </div>
-
-        <%= submit "Save changes", class: "button is-link" %>
-    </form>
+    </div>
 </div>

--- a/lib/plan_picker_web/templates/enrollment_management/edit.html.leex
+++ b/lib/plan_picker_web/templates/enrollment_management/edit.html.leex
@@ -1,5 +1,5 @@
 <div class="column is-one-quarter">
-    <%= form_for @changeset, Routes.enrollment_management_path(@conn, :update, %{"id" => @enrollment_id}), fn f -> %>
+    <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :submit] %>
         <%= if @changeset.action do %>
             <div class="alert alert-danger">
                 <p>Oops, something went wrong! Please check the errors below.</p>
@@ -23,5 +23,5 @@
         </div>
 
         <%= submit "Save changes", class: "button is-link" %>
-    <% end %>
+    </form>
 </div>

--- a/lib/plan_picker_web/templates/enrollment_management/edit.html.leex
+++ b/lib/plan_picker_web/templates/enrollment_management/edit.html.leex
@@ -1,6 +1,6 @@
 <h1 class="title"> Edit <%= @enrollment.name %> </h1>
 <div class="columns">
-    <div class="column is-one-fifth">
+    <div class="column is-one-quarter">
         <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :submit] %>
             <%= if @changeset.action do %>
                 <div class="alert alert-danger">
@@ -28,7 +28,7 @@
         </form>
     </div>
 
-    <div class="columns column is-two-fifths">
+    <div class="columns column">
         <div class="column">
             <button class="button is-primary is-fullwidth" phx-click="assign_users">
                 Assign users &rarr;

--- a/lib/plan_picker_web/templates/enrollment_management/index.html.eex
+++ b/lib/plan_picker_web/templates/enrollment_management/index.html.eex
@@ -1,4 +1,4 @@
-<h1> Your enrollments </h1>
+<h1> Enrollments </h1>
 
 <ol>
     <%= for enrollment <- @enrollments do %>

--- a/lib/plan_picker_web/templates/enrollment_management/index.html.eex
+++ b/lib/plan_picker_web/templates/enrollment_management/index.html.eex
@@ -1,6 +1,6 @@
-<h1> Enrollments </h1>
+<h1 class="title"> Enrollments </h1>
 <%= if is_admin?(@conn) do %>
-    <div>
+    <div class="block">
         <%= button "Add new", to: Routes.enrollment_management_path(@conn, :new), method: :get, class: "is-link button" %>
     </div>
 <% end %>

--- a/lib/plan_picker_web/templates/enrollment_management/index.html.eex
+++ b/lib/plan_picker_web/templates/enrollment_management/index.html.eex
@@ -1,5 +1,9 @@
 <h1> Enrollments </h1>
-
+<%= if is_admin?(@conn) do %>
+    <div>
+        <%= button "Add new", to: Routes.enrollment_management_path(@conn, :new), method: :get, class: "is-link button" %>
+    </div>
+<% end %>
 <ol>
     <%= for enrollment <- @enrollments do %>
         <li> <%= link enrollment.name, to: Routes.enrollment_management_path(@conn, :show, enrollment.id) %> (<%= enrollment.state %>) </li>

--- a/lib/plan_picker_web/templates/enrollment_management/show.html.eex
+++ b/lib/plan_picker_web/templates/enrollment_management/show.html.eex
@@ -1,6 +1,13 @@
 <h1 class="title"> <%= @enrollment.name %> </h1>
 <h2 class="subtitle"> <%= @enrollment.state %> </h2>
 
+<div class="block">
+    <%= button "Edit enrollment", to: Routes.enrollment_management_path(@conn, :edit, @enrollment.id), method: :get, class: "button is-link" %>
+    <%= if is_admin?(@conn) do %>
+        <%= button "Delete enrollment", to: Routes.enrollment_management_path(@conn, :delete, @enrollment.id), method: :delete, class: "button is-danger" %>
+    <% end %>
+</div>
+
 <div class="content columns">
     <div class="column">
         <h3> Assigned users </h3>

--- a/lib/plan_picker_web/templates/enrollment_management/show.html.eex
+++ b/lib/plan_picker_web/templates/enrollment_management/show.html.eex
@@ -1,1 +1,22 @@
-Enrollment view (admin)
+<h1 class="title"> <%= @enrollment.name %> </h1>
+<h2 class="subtitle"> <%= @enrollment.state %> </h2>
+
+<div class="content columns">
+    <div class="column">
+        <h3> Assigned users </h3>
+        <%= for user <- @enrollment.users do %>
+            <div>
+                <%= user.name %> <%= user.last_name %>, <%= user.index_no %>
+            </div>
+        <% end %>
+    </div>
+
+    <div class="column">
+        <h3> Subjects </h3>
+        <%= for subject <- @enrollment.subjects do %>
+            <div>
+                <%= subject.name %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/lib/plan_picker_web/views/enrollment_management_view.ex
+++ b/lib/plan_picker_web/views/enrollment_management_view.ex
@@ -1,3 +1,11 @@
 defmodule PlanPickerWeb.EnrollmentManagementView do
   use PlanPickerWeb, :view
+  alias PlanPicker.Role
+  alias PlanPickerWeb.UserAuth
+
+  defp user_has_role?(conn, role) do
+    conn |> UserAuth.current_user() |> Role.has_role?(role)
+  end
+
+  def is_admin?(conn), do: user_has_role?(conn, :admin)
 end

--- a/lib/plan_picker_web/views/enrollment_management_view.ex
+++ b/lib/plan_picker_web/views/enrollment_management_view.ex
@@ -1,15 +1,5 @@
 defmodule PlanPickerWeb.EnrollmentManagementView do
   use PlanPickerWeb, :view
-  alias PlanPicker.Role
-  alias PlanPickerWeb.UserAuth
 
-  defp user_has_role?(conn, role) do
-    conn |> UserAuth.current_user() |> Role.has_role?(role)
-  end
-
-  def is_admin?(conn), do: user_has_role?(conn, :admin)
-
-  def selected?(selected, el) do
-    Enum.member?(selected, el)
-  end
+  def selected?(selected, el), do: el in selected
 end

--- a/lib/plan_picker_web/views/enrollment_management_view.ex
+++ b/lib/plan_picker_web/views/enrollment_management_view.ex
@@ -8,4 +8,8 @@ defmodule PlanPickerWeb.EnrollmentManagementView do
   end
 
   def is_admin?(conn), do: user_has_role?(conn, :admin)
+
+  def selected?(selected, el) do
+    Enum.member?(selected, el)
+  end
 end

--- a/lib/plan_picker_web/views/role_helpers.ex
+++ b/lib/plan_picker_web/views/role_helpers.ex
@@ -1,0 +1,15 @@
+defmodule PlanPickerWeb.RoleHelpers do
+  alias PlanPicker.Role
+  alias PlanPickerWeb.UserAuth
+
+  def user_has_role?(conn, role) do
+    case UserAuth.current_user(conn) do
+      nil -> false
+      user -> Role.has_role?(user, role)
+    end
+  end
+
+  def is_admin?(conn), do: user_has_role?(conn, :admin)
+
+  def is_moderator?(conn), do: user_has_role?(conn, :moderator)
+end


### PR DESCRIPTION
Should work as intended now

Index screen ("Add new" button visible only to admin)
![image](https://user-images.githubusercontent.com/39308576/121813355-f772e080-cc6b-11eb-9210-cb0b0042fa2a.png)

Adding new enrollment - same as was previously
![image](https://user-images.githubusercontent.com/39308576/121813371-0c4f7400-cc6c-11eb-9555-d1a428ccf57d.png)

Enrollment details ("Delete" button only for admin again)
![image](https://user-images.githubusercontent.com/39308576/121813398-27ba7f00-cc6c-11eb-9106-a72405cc78de.png)

Edit enrollment
![image](https://user-images.githubusercontent.com/39308576/121813421-3dc83f80-cc6c-11eb-91ad-33bc50d7c5ae.png)

Select users and assign them to enrollment
![image](https://user-images.githubusercontent.com/39308576/121813431-5173a600-cc6c-11eb-815b-49ed286fda4c.png)
Or unassign
![image](https://user-images.githubusercontent.com/39308576/121813447-63eddf80-cc6c-11eb-9983-fcf0c8a64cde.png)

If there are users selected in both columns, only the relevant column will be used